### PR TITLE
Using max_id query param to download much more of a user's TL

### DIFF
--- a/person_bot.py
+++ b/person_bot.py
@@ -21,13 +21,31 @@ average_interval = 7200
 
 def get_tweets(username):
     '''(str) -> list of tweets,
-    fetches last 200 tweets from specified user'''
+    fetches last 3200 tweets from specified user'''
     try:
-        user_timeline = twitter.get_user_timeline(
-            screen_name=username, count=200, include_rts=False, exclude_replies=True)
-        tweets = [user_timeline[i]['text']
-                  for i in range(len(user_timeline) - 1)]
+        tweets = []
+        max_id = None
+        for _ in range(16):
+            if max_id is None:
+                user_timeline = twitter.get_user_timeline(
+                    screen_name=username, count=200,
+                    include_rts=False, exclude_replies=True)
+            else:
+                user_timeline = twitter.get_user_timeline(
+                    screen_name=username, count=200,
+                    include_rts=False, exclude_replies=True,
+                    max_id=max_id)
+            new_tweets = [user_timeline[i]['text']
+                      for i in range(len(user_timeline))]
+            if len(new_tweets) == 0:
+                return tweets
+            tweets += new_tweets
+            max_id = min([user_timeline[i]['id']
+                          for i in range(len(user_timeline))])
+            max_id -= 1  # max_id is inclusive, so sub 1 to avoid repeats.
+
         return tweets
+
     except TwythonError as e:
         print e
         return e


### PR DESCRIPTION
The official twitter limits are 200 tweets per user_timeline query, but 3200 accessible tweets in total. This PR will handle obtaining the additional 3000 past the first query.
