### PR TITLE
Downloading more tweets + tweet caching

### DIFF
--- a/markov.py
+++ b/markov.py
@@ -69,6 +69,8 @@ def fix_therest(text):
     quote_hack = re.sub(r"“”“", r'', nna_hack)
     if quote_hack[0:2] == "'s":
         clean = quote_hack[3:]
+    else:
+        clean = quote_hack
     return clean
 
 

--- a/person_bot.py
+++ b/person_bot.py
@@ -19,45 +19,99 @@ minimum_interval = 300
 average_interval = 7200
 
 
+def tweets_from_timeline(timeline):
+    '''timeline -> list of tweets
+    '''
+    return [timeline[i]['text']
+            for i in range(len(timeline))]
+
+
+def ids_from_timeline(timeline):
+    '''timeline -> list of numbers
+    '''
+    return [timeline[i]['id']
+            for i in range(len(timeline))]
+
+
 def get_tweets(username):
-    '''(str) -> list of tweets,
-    fetches last 200 tweets from specified user'''
+    '''(str) -> (list of tweets, id of most recent tweet),
+    fetches last 3200 tweets from specified user'''
     try:
-        user_timeline = twitter.get_user_timeline(
-            screen_name=username, count=200, include_rts=False, exclude_replies=True)
-        tweets = [user_timeline[i]['text']
-                  for i in range(len(user_timeline) - 1)]
-        return tweets
+        tweets = []
+        since_id = None
+        max_id = None
+        for _ in range(16):
+            if max_id is None:
+                user_timeline = twitter.get_user_timeline(
+                    screen_name=username, count=200,
+                    include_rts=False, exclude_replies=True)
+                since_id = max(ids_from_timeline(user_timeline))
+            else:
+                user_timeline = twitter.get_user_timeline(
+                    screen_name=username, count=200,
+                    include_rts=False, exclude_replies=True,
+                    max_id=max_id)
+            new_tweets = tweets_from_timeline(user_timeline)
+            if len(new_tweets) == 0:
+                return (tweets, since_id)
+            tweets += new_tweets
+            max_id = min(ids_from_timeline(user_timeline))
+            max_id -= 1  # max_id is inclusive, so sub 1 to avoid repeats.
+        return (tweets, since_id)
     except TwythonError as e:
         print e
         return e
 
 
-def generate_status(tweet_list):
-    '''(list) -> str,
-    returns markov-generated status'''
-    tweet_text = ' '.join(tweet_list)
+def get_new_tweets(username, since_id):
+    '''str, number -> list of tweets, number
+    fetches any new tweets made after |since_id|'''
     try:
-        mc = MarkovGenerator(tweet_text, 90, tokenize_fun=twitter_tokenize)
-        status = mc.generate_words().lower()
-        return status
-    except ValueError as e:
+        user_timeline = twitter.get_user_timeline(
+            screen_name=username, count=200,
+            include_rts=False, exclude_replies=True,
+            since_id=since_id)
+        if len(user_timeline) == 0:
+            return (None, None)
+        tweets = tweets_from_timeline(user_timeline)
+        since_id = max(ids_from_timeline(user_timeline))
+        return (tweets, since_id)
+    except TwythonError as e:
         print e
-        pass
+        return e
 
 
-def ebook():
-    '''posts generated status to twitter'''
-    status = generate_status(get_tweets(user))
+def post_tweet_from_generator(generator):
+    '''generates a status, posts it to twitter and logs it'''
+    status = generator.generate_words().lower()
     try:
         twitter.update_status(status=status)
-        print time.strftime('[%y-%m-%dT%H:%M:%S] {}').format(status)
+        print time.strftime('[%y-%m-%dT%H:%M:%S] {}').encode('utf-8').format(status)
         time.sleep(minimum_interval -
                    log(random()) * (average_interval - minimum_interval))
     except TwythonError as e:
         print e
         pass
 
-if __name__ == '__main__':
+def ebook():
+    '''the loop with all the action'''
+    tweet_list, since_id = get_tweets(user)
+    update_markov = True
     while True:
-        ebook()
+        if update_markov:
+            tweet_text = ' '.join(tweet_list)
+            mc = MarkovGenerator(tweet_text, 90, tokenize_fun=twitter_tokenize)
+            update_markov = False
+
+        post_tweet_from_generator(mc)
+
+        # download new tweets
+        new_tweet_list, new_since_id = get_new_tweets(user, since_id)
+        if len(new_tweet_list) != 0:
+            tweet_list += new_tweet_list
+            since_id = new_since_id
+            update_markov = True
+
+
+if __name__ == "__main__":
+    ebook()


### PR DESCRIPTION
This contains the changes from #4 plus a change to the core ebook method to cache tweets already obtained and only request new tweets after the initial scrape. This should make it much less likely to exceed the rate limit. The bot would have to post 162 new tweets in the 15min window after starting to exceed it, which the default time limits should prevent.
